### PR TITLE
Fix vF in 8xy4/5/6/7/E, Fix F key not being read

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,4 +12,4 @@ DESCRIPTION ?= "CHIP8 Emu"
 
 # ----------------------------
 
-include $(CEDEV)/include/.makefile
+include $(shell cedev-config --makefile)

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -310,14 +310,16 @@ void emulateCycle(uint8_t steps) {
 						break;
 					}
 					case 0x0004: {
-						V[0xf] = (V[x] + V[y] > 0xff);
+						i = (V[x] + V[y] > 0xff); //vF set after operation
 						V[x] += V[y];
 						V[x] &= 255;
+						V[0xf] = i;
 						break;
 					}
 					case 0x0005: {
-						V[0xf] = V[x] >= V[y];
+						i = V[x] >= V[y];
 						V[x] -= V[y];
+						V[0xf] = i;
 						break;
 					}
 					case 0x0006: {
@@ -326,8 +328,9 @@ void emulateCycle(uint8_t steps) {
 						break;
 					}
 					case 0x0007: {
-						V[0xf] = V[y] >= V[x];
+						i = V[y] >= V[x]; //vF needs to be set after the subtraction hence the temp variable
 						V[x] = V[y] - V[x];
+						V[0xF] = i;
 						break;
 					}
 					case 0x000E: {

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -78,7 +78,7 @@ uint16_t  fontset_ten[80] = {
 
 uint8_t step;
 uint16_t pixel;
-uint16_t index;
+uint16_t cindex;
 
 uint8_t _y;
 uint8_t _x;
@@ -378,12 +378,12 @@ void emulateCycle(uint8_t steps) {
 						}
 						for(_x = 0; _x < (cols << 3); ++_x) {
 							if((pixel & (((cols == 2) ? 0x8000 : 0x80) >> _x)) != 0) {
-								index = (((xd + _x) & 0x7f) + (((yd + _y) & 0x3f) << 7)) + 2;
-								V[0xf] |= canvas_data[index] & 1;
-								if (canvas_data[index])
-									canvas_data[index] = 0;
+								cindex = (((xd + _x) & 0x7f) + (((yd + _y) & 0x3f) << 7)) + 2;
+								V[0xf] |= canvas_data[cindex] & 1;
+								if (canvas_data[cindex])
+									canvas_data[cindex] = 0;
 								else
-									canvas_data[index] = 1;
+									canvas_data[cindex] = 1;
 							}
 						}
 					}
@@ -394,12 +394,12 @@ void emulateCycle(uint8_t steps) {
 						pixel = memory[I + _y];
 						for(_x = 0; _x < 8; ++_x) {
 							if((pixel & (0x80 >> _x)) != 0) {
-								index = (((xd + _x) & 0x3f) + (((yd + _y) & 0x1f) << 6)) + 2;
-								V[0xf] |= canvas_data[index] & 1;
-								if (canvas_data[index])
-									canvas_data[index] = 0;
+								cindex = (((xd + _x) & 0x3f) + (((yd + _y) & 0x1f) << 6)) + 2;
+								V[0xf] |= canvas_data[cindex] & 1;
+								if (canvas_data[cindex])
+									canvas_data[cindex] = 0;
 								else
-									canvas_data[index] = 1;
+									canvas_data[cindex] = 1;
 							}
 						}
 					}

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -160,7 +160,7 @@ void setKeys() {
 	keypad[0xE] = kb_Data[6] & kb_Add;
 	keypad[0xF] = kb_Data[6] & kb_Enter;
 	
-	for(i = 0; i < 15; i++) {
+	for(i = 0; i < 16; i++) {
 		keys[i] = keypad[controlMap[i]];
 	}
 	

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -323,8 +323,9 @@ void emulateCycle(uint8_t steps) {
 						break;
 					}
 					case 0x0006: {
-						V[0xf] = V[x] & 1;
+						i = V[x] & 1;
 						V[x] >>= 1;
+						V[0xf] = i;
 						break;
 					}
 					case 0x0007: {
@@ -334,8 +335,9 @@ void emulateCycle(uint8_t steps) {
 						break;
 					}
 					case 0x000E: {
-						V[0xf] = V[x] >> 7;
+						i = V[x] >> 7;
 						V[x] <<= 1;
+						V[0xf] = i;
 						break;
 					}
 					break;

--- a/src/main.c
+++ b/src/main.c
@@ -127,7 +127,7 @@ void main(void) {
 	gfx_PrintStringXY("Chip-84", 103, 95);
 	gfx_SetTextScale(1, 1);
 	gfx_PrintStringXY("2018 Christian Kosman", 80, 120);
-	gfx_PrintStringXY("version 2.3.3", LCD_WIDTH-100, LCD_HEIGHT-30);
+	gfx_PrintStringXY("version 2.3.4 ", LCD_WIDTH-100, LCD_HEIGHT-30);
 	gfx_BlitBuffer();
 	
 	delay(1000);

--- a/src/main.c
+++ b/src/main.c
@@ -127,6 +127,7 @@ void main(void) {
 	gfx_PrintStringXY("Chip-84", 103, 95);
 	gfx_SetTextScale(1, 1);
 	gfx_PrintStringXY("2018 Christian Kosman", 80, 120);
+	gfx_PrintStringXY("Updated 2022 by oxiti8", 78, 140);
 	gfx_PrintStringXY("version 2.3.4 ", LCD_WIDTH-100, LCD_HEIGHT-30);
 	gfx_BlitBuffer();
 	


### PR DESCRIPTION
This PR mainly fixes some bugs with how vF is set in the 8XYx ops, having it be set after the operation with the flag being set before the operation. It also changes a variable name ("index" to "cindex") and the makefile in order to get this to compile on the latest toolchain (V10.2 at the time of writing), and fixes an off-by-one error during key polling that prevented the key for "F" from ever being read.